### PR TITLE
Auto Logging for Battle

### DIFF
--- a/checkers/auto_battle_log.py
+++ b/checkers/auto_battle_log.py
@@ -11,16 +11,6 @@ class BattleManager:
     expire_time = 10 * 60 # After how many minutes should the keys be cleared.
     _open_battles: dict[int, list[dict]] = {}
 
-    """
-    _open_battles structure = 
-    {
-    'server_id': [
-    {'challenger': id, 'target': id, 'expiration': time},
-    {'challenger 2': id, 'target 2': id, 'expiration 2': time},
-    ]
-    }
-    """
-
     async def clear_user(self, guild_id: int, index: int):
         """Run if a user start another battle and current battle hasnot ended."""
         if self._open_battles.get(guild_id, []):


### PR DESCRIPTION
Added:

1. Detection 
2. Cancelling
3. Logging

Removed the `bot.wait_for()` function and in return it checks the messages sent by poketwo to determine the winner of the message. 

It uses the cache to store the current battles in the following format in `_open_battles` attribute of the `BattleManager` class:-

```py
_open_battles = {
    'server_id': [
        {
            'challenger': 1234,
            'target': 12345, 
            'challenger_n': 'name', 
            'target_n': 'name', 
            'expire': 'datetime object'
        }, 
        # second challenger details
        {
            'challenger': 1234,
            'target': 12345, 
            'challenger_n': 'name', 
            'target_n': 'name', 
            'expire': 'datetime object'
        }
    ]
}
```

Expire key is the limit of time to wait before the data gets cleared. Currently its **10 mins**